### PR TITLE
Nodemailer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,9 @@ JWT_VERIFY_EMAIL_EXPIRATION_MINUTES=10
 # For testing, you can use a fake SMTP service like Ethereal: https://ethereal.email/create
 SMTP_HOST=email-server
 SMTP_PORT=587
+# SMTP_SECURE Use TLS or upgrade later with STARTTLS
+SMTP_SECURE=false
+SMTP_REJECT_SELFSIGNED_CERTS=false
 SMTP_USERNAME=email-server-username
 SMTP_PASSWORD=email-server-password
 EMAIL_FROM=support@yourapp.com

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ yarn-error.log
 
 # Code coverage
 coverage
+.husky/_

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -20,6 +20,8 @@ const envVarsSchema = Joi.object()
       .description('minutes after which verify email token expires'),
     SMTP_HOST: Joi.string().description('server that will send the emails'),
     SMTP_PORT: Joi.number().description('port to connect to the email server'),
+    SMTP_SECURE: Joi.boolean().description('Use TLS or upgrade later with STARTTLS'),
+    SMTP_REJECT_SELFSIGNED_CERTS: Joi.boolean().description('Accept or Reject self-signed certificates.'),
     SMTP_USERNAME: Joi.string().description('username for email server'),
     SMTP_PASSWORD: Joi.string().description('password for email server'),
     EMAIL_FROM: Joi.string().description('the from field in the emails sent by the app'),
@@ -54,9 +56,13 @@ module.exports = {
     smtp: {
       host: envVars.SMTP_HOST,
       port: envVars.SMTP_PORT,
+      secure: envVars.SMTP_SECURE,
       auth: {
         user: envVars.SMTP_USERNAME,
         pass: envVars.SMTP_PASSWORD,
+      },
+      tls: {
+        rejectUnauthorized: envVars.SMTP_REJECT_SELFSIGNED_CERTS,
       },
     },
     from: envVars.EMAIL_FROM,

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -7,8 +7,14 @@ const transport = nodemailer.createTransport(config.email.smtp);
 if (config.env !== 'test') {
   transport
     .verify()
-    .then(() => logger.info('Connected to email server'))
-    .catch(() => logger.warn('Unable to connect to email server. Make sure you have configured the SMTP options in .env'));
+    .then(() => {
+      logger.info(`Email transport verify successful`);
+    })
+    .catch((error) => {
+      logger.warn(`Email transport verify returned: ${error}`);
+      logger.warn(`Unable to make connection to ${config.email.smtp.host}:${config.email.smtp.port}`);
+      logger.warn('Make sure you have configured the SMTP options in .env');
+    });
 }
 
 /**


### PR DESCRIPTION
The `transport.verify().then().catch()` thing failing 100% even after successful connection to mail server.
Changing to `verify((error, success) => {})` fixed that.

`nodemailer.createTransport(options);` has an option to control if **TLS** is _required_ or
if **STARTTLS** should be tried.

Added **SMTP_SECURE** option to `.env`

This is what `verify()` looks like on the mail server: (_followed by what the firewall thinks of things_)

	: NOQUEUE: connect from client.example.com [1.2.3.144]
	: AUTH: available mech=PLAIN, allowed mech=EXTERNAL GSSAPI KERBEROS_V4 DIGEST-MD5 CRAM-MD5
	: 13QGhgnj025999: Milter (smf-grey): init success to negotiate
	: 13QGhgnj025999: Milter (clamav-milter): init success to negotiate
	: 13QGhgnj025999: Milter (smf-spamd): init success to negotiate
	: 13QGhgnj025999: Milter: connect to filters
	: 13QGhgnj025999: milter=smf-grey, action=connect, accepted
	: 13QGhgnj025999: milter=clamav-milter, action=connect, continue
	: 13QGhgnj025999: milter=smf-spamd, action=connect, continue
	: 13QGhgnj025999: --- 220 mail.example.com ESMTP Sendmail 8.15.2/8.15.2; Mon, 26 Apr 2021 18:43:42 +0200
	: 13QGhgnj025999: <-- EHLO [127.0.0.1]
	: 13QGhgnj025999: milter=smf-spamd, action=helo, continue
	: 13QGhgnj025999: --- 250-mail.example.com Hello client.example.com [1.2.3.144], pleased to meet you
	: 13QGhgnj025999: --- 250-ENHANCEDSTATUSCODES
	: 13QGhgnj025999: --- 250-PIPELINING
	: 13QGhgnj025999: --- 250-8BITMIME
	: 13QGhgnj025999: --- 250-SIZE
	: 13QGhgnj025999: --- 250-DSN
	: 13QGhgnj025999: --- 250-ETRN
	: 13QGhgnj025999: --- 250-STARTTLS
	: 13QGhgnj025999: --- 250-DELIVERBY
	: 13QGhgnj025999: --- 250 HELP
	: 13QGhgnj025999: <-- STARTTLS
	: 13QGhgnj025999: --- 220 2.0.0 Ready to start TLS
	: STARTTLS: x509 cert verify: depth=0 /C=DK/ST=Denmark/L=Copenhagen/O=Example/OU=Mailserver Cert/CN=mail.example.com/emailAddress=hostmaster@example.com, state=0, reason=unable to get certificate CRL
	: STARTTLS: x509 cert verify: depth=1 /C=DK/ST=Denmark/L=Copenhagen/O=Example Corp/OU=Certification Services Division/CN=Example Corp Root CA/emailAddress=hostmaster@example.com, state=0, reason=unable to get certificate CRL
	: STARTTLS=server, get_verify: 0 get_peer: 0x0
	: STARTTLS=server, relay=client.example.com [1.2.3.144], version=TLSv1.2, verify=NO, cipher=DHE-RSA-AES128-GCM-SHA256, bits=128/128
	: STARTTLS=server, cert-subject=, cert-issuer=, verifymsg=ok
	: AUTH: available mech=PLAIN, allowed mech=EXTERNAL GSSAPI KERBEROS_V4 DIGEST-MD5 CRAM-MD5
	: STARTTLS=read, info: fds=9/3, err=2
	: 13QGhgnj025999: --- 421 4.4.1 mail.example.com Lost input channel from client.example.com [1.2.3.144]
	: 13QGhgnj025999: client.example.com [1.2.3.144] did not issue MAIL/EXPN/VRFY/ETRN during connection to MTA

The firewall does not like the way **nodemailer** behaves, but this connecting client is _whitelisted_

	: Enter dbcheckwhitelist: 1.2.3.144 
	: Blacklist IP: 1.2.3.144 - MAIL/EXPN/VRFY/ETRN 
	: Enter dbblacklist: 1.2.3.144 - MAIL/EXPN/VRFY/ETRN 
	: LOCALNET: Whitelisted host at 1.2.3.144 -- NOT BLACKLISTING 
