### PR TITLE
Fix function documentation

### DIFF
--- a/src/services/token.service.js
+++ b/src/services/token.service.js
@@ -102,7 +102,7 @@ const generateResetPasswordToken = async (email) => {
 
 /**
  * Generate verify email token
- * @param {string} email
+ * @param {User} user
  * @returns {Promise<string>}
  */
 const generateVerifyEmailToken = async (user) => {


### PR DESCRIPTION
Since generateVerifyEmailToken(user) takes a user object and not a string I fixed the incorrect documentation.