### PR TITLE
fix function documentation

### DIFF
--- a/src/services/token.service.js
+++ b/src/services/token.service.js
@@ -11,6 +11,7 @@ const { tokenTypes } = require('../config/tokens');
  * Generate token
  * @param {ObjectId} userId
  * @param {Moment} expires
+ * @param {string} type
  * @param {string} [secret]
  * @returns {string}
  */


### PR DESCRIPTION
fix missing **`type`** param documentation on `generateToken(userId, expires, type, secret = config.jwt.secret)` function.