### PR TITLE
fix: TTL index tokens

### DIFF
--- a/src/models/token.model.js
+++ b/src/models/token.model.js
@@ -22,6 +22,7 @@ const tokenSchema = mongoose.Schema(
     expires: {
       type: Date,
       required: true,
+      expires: 0,
     },
     blacklisted: {
       type: Boolean,


### PR DESCRIPTION
It seems Token model doesn't create TTL index correctly.

I read [mongoose docs](https://mongoosejs.com/docs/api.html#schemadateoptions_SchemaDateOptions-expires) that says we should add **expires** as `SchemaDateOptions`, not just schema property.

> SchemaDateOptions.prototype.expires
> Type:
> «Date»
> If set, Mongoose creates a TTL index on this path.

```js
// token.model.js
type: {
  ...
}
expires: {
  type: Date,
  required: true,
  expires: 0, // this, expire docs 0 seconds after expires Date
},
blacklisted: {
  ...
},
```
since this behavior [won't be able to test according to mongoose#10307.](https://github.com/Automattic/mongoose/issues/10307)
so, I decided to check this behavior by manually send `Token.find()` to user. And setting `config.jwt.refreshExpirationDays` to only 2 minutes, then periodically see the result.

with current Token Schema:
![Screenshot 2021-06-10 100224x](https://user-images.githubusercontent.com/37757388/121459516-9cc05700-c9d5-11eb-9df9-8f96b2ca0b54.png)

this tokens won't be usable since expired, but this can be massive obsolete tokens in database.