### PR TITLE
Add check for mongoose connection error with log and 500 response (Issue #151)

### DIFF
--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -2,8 +2,14 @@ const passport = require('passport');
 const httpStatus = require('http-status');
 const ApiError = require('../utils/ApiError');
 const { roleRights } = require('../config/roles');
+const logger = require('../config/logger');
 
 const verifyCallback = (req, resolve, reject, requiredRights) => async (err, user, info) => {
+  if (err && err.stack.includes('MongooseServerSelectionError')) {
+    logger.error(err);
+    return reject(new ApiError(httpStatus.INTERNAL_SERVER_ERROR, 'Internal server error'));
+  }
+
   if (err || info || !user) {
     return reject(new ApiError(httpStatus.UNAUTHORIZED, 'Please authenticate'));
   }


### PR DESCRIPTION
This PR is related to Issue #151 . 

I haven't added a test case for this and am awaiting review and feedback on the proposed solution, as I agree there might be a preferred method to test for and/or handle Mongoose/MongoDB connection errors which occur after app is initially started with a good mongoose connection at start.

Suggestions are happily welcomed!