### PR TITLE
Fix constructor parameters

### DIFF
--- a/src/utils/ApiError.js
+++ b/src/utils/ApiError.js
@@ -1,5 +1,5 @@
 class ApiError extends Error {
-  constructor(statusCode, message, isOperational = true, stack = '') {
+  constructor(statusCode, message, stack = '', isOperational = true) {
     super(message);
     this.statusCode = statusCode;
     this.isOperational = isOperational;


### PR DESCRIPTION
Updated the ApiError class adding the 'stack' parameter on the constructor before the isOperational parameter.