### PR TITLE
Updates verify-email to HTTP method GET

### DIFF
--- a/src/routes/v1/auth.route.js
+++ b/src/routes/v1/auth.route.js
@@ -13,7 +13,7 @@ router.post('/refresh-tokens', validate(authValidation.refreshTokens), authContr
 router.post('/forgot-password', validate(authValidation.forgotPassword), authController.forgotPassword);
 router.post('/reset-password', validate(authValidation.resetPassword), authController.resetPassword);
 router.post('/send-verification-email', auth(), authController.sendVerificationEmail);
-router.post('/verify-email', validate(authValidation.verifyEmail), authController.verifyEmail);
+router.get('/verify-email', validate(authValidation.verifyEmail), authController.verifyEmail);
 
 module.exports = router;
 

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -48,7 +48,7 @@ If you did not request any password resets, then ignore this email.`;
 const sendVerificationEmail = async (to, token) => {
   const subject = 'Email Verification';
   // replace this url with the link to the email verification page of your front-end app
-  const verificationEmailUrl = `http://link-to-app/verify-email?token=${token}`;
+  const verificationEmailUrl = `http://link-to-app/v1/auth/verify-email?token=${token}`;
   const text = `Dear user,
 To verify your email, click on this link: ${verificationEmailUrl}
 If you did not create an account, then ignore this email.`;


### PR DESCRIPTION
The current verify-email HTTP method is set to POST. Which would not work on email link click.

Updates change method to GET and also update sample email content of send verification email to correct path.