### PR TITLE
Resolution for issue #281

### DIFF
--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -29,7 +29,7 @@ const logout = async (refreshToken) => {
   if (!refreshTokenDoc) {
     throw new ApiError(httpStatus.NOT_FOUND, 'Not found');
   }
-  await refreshTokenDoc.remove();
+  await refreshTokenDoc.deleteOne();
 };
 
 /**
@@ -44,7 +44,7 @@ const refreshAuth = async (refreshToken) => {
     if (!user) {
       throw new Error();
     }
-    await refreshTokenDoc.remove();
+    await refreshTokenDoc.deleteOne();
     return tokenService.generateAuthTokens(user);
   } catch (error) {
     throw new ApiError(httpStatus.UNAUTHORIZED, 'Please authenticate');

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -75,7 +75,7 @@ const deleteUserById = async (userId) => {
   if (!user) {
     throw new ApiError(httpStatus.NOT_FOUND, 'User not found');
   }
-  await user.remove();
+  await user.deleteOne();
   return user;
 };
 


### PR DESCRIPTION
Resolves issue #281 "Mongoose V5.5.3+ introduced .remove() deprecation" by updating the auth.service.js and user.service.js to use .deleteOne() as opposed to .remove() which now throws an error in updated mongoose versions V5.5.3 or higher.