### PR TITLE
Fix: add min/max password length validation for auth

### DIFF
--- a/src/validations/auth.validation.js
+++ b/src/validations/auth.validation.js
@@ -4,7 +4,7 @@ const { password } = require('./custom.validation');
 const register = {
   body: Joi.object().keys({
     email: Joi.string().required().email(),
-    password: Joi.string().required().custom(password),
+    password: Joi.string().min(8).max(32).required().custom(password),
     name: Joi.string().required(),
   }),
 };
@@ -39,7 +39,7 @@ const resetPassword = {
     token: Joi.string().required(),
   }),
   body: Joi.object().keys({
-    password: Joi.string().required().custom(password),
+    password: Joi.string().min(8).max(32).required().custom(password),
   }),
 };
 


### PR DESCRIPTION
### What
Added minimum and maximum length validation for passwords in the registration and reset password flows.

### Why
Passwords previously had no upper bound, allowing extremely long values which could lead to performance issues and potential abuse.  
This change aligns the validation with common industry security standards.

### Changes
- Enforced minimum password length of 8 characters
- Enforced maximum password length of 32 characters
- Applied validation consistently to register and reset password endpoints
- Preserved existing password complexity rules (letters + numbers)

### Testing
Manually tested using curl:
-  valid password accepted
-  short password rejected
-  long password rejected
-  missing number rejected
-  missing letter rejected

### Screenshots
<details>
<summary>Validation test outputs</summary>

<img width="1494" height="106" alt="valid password" src="https://github.com/user-attachments/assets/7800d0d4-8639-43c5-a39a-b01ff82b334e" />
<img width="1472" height="90" alt="short password" src="https://github.com/user-attachments/assets/5cc9e442-57fc-4503-9e46-b941d2e39d07" />
<img width="1197" height="94" alt="long password" src="https://github.com/user-attachments/assets/57cfb2c3-697e-4059-93e3-a7d49a1db6da" />
<img width="1229" height="98" alt="missing number" src="https://github.com/user-attachments/assets/3ee20c06-b3b4-45c4-94e8-764dd0bafd6b" />
<img width="860" height="89" alt="missing letter" src="https://github.com/user-attachments/assets/a7463532-e54c-4628-852e-4303aa31d632" />

</details>

Closes #302
