### PR TITLE
fix: correct docs route test environment and add development test

### DIFF
--- a/tests/integration/docs.test.js
+++ b/tests/integration/docs.test.js
@@ -1,14 +1,31 @@
 const request = require('supertest');
 const httpStatus = require('http-status');
 const app = require('../../src/app');
-const config = require('../../src/config/config');
 
-describe('Auth routes', () => {
+describe('Docs routes', () => {
   describe('GET /v1/docs', () => {
     test('should return 404 when running in production', async () => {
-      config.env = 'production';
-      await request(app).get('/v1/docs').send().expect(httpStatus.NOT_FOUND);
-      config.env = process.env.NODE_ENV;
+      const originalEnv = process.env.NODE_ENV;
+
+      process.env.NODE_ENV = 'production';
+
+      const res = await request(app).get('/v1/docs');
+
+      expect(res.statusCode).toBe(httpStatus.NOT_FOUND);
+
+      process.env.NODE_ENV = originalEnv;
+    });
+
+    test('should return redirect when running in development', async () => {
+      const originalEnv = process.env.NODE_ENV;
+
+      process.env.NODE_ENV = 'development';
+
+      const res = await request(app).get('/v1/docs');
+
+      expect([301, 302]).toContain(res.statusCode);
+
+      process.env.NODE_ENV = originalEnv;
     });
   });
 });


### PR DESCRIPTION
Fixed incorrect environment handling in docs route test. Replaced config.env with process.env.NODE_ENV.

Added test to verify docs route behavior in development environment. Handled redirect status (301/302) for compatibility.